### PR TITLE
feat(DUV-1621): doc source fix

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -13,7 +13,7 @@ module.exports = {
         },
       },
     },
-    '@storybook/addon-storysource',
+    // '@storybook/addon-storysource', // see https://github.com/storybookjs/storybook/issues/13362#issuecomment-779804329
     '@storybook/addon-actions',
     '@storybook/addon-links',
     '@storybook/addon-knobs',

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -24,6 +24,7 @@ const componentsConfig = components
     ],
     output: [
       {
+        exports: 'auto',
         format: 'cjs',
         dir: `${__dirname}/core`,
         entryFileNames: '[name].js',


### PR DESCRIPTION
Two addons were clashing so removed the addons-storysource in favor of addons-docs
See: https://github.com/storybookjs/storybook/issues/13362#issuecomment-779804329 for more information

<img width="999" alt="image" src="https://user-images.githubusercontent.com/31204019/143550721-98df352e-f173-421d-9454-9b4a9f64c919.png">
